### PR TITLE
Add basic web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,18 @@ python script.py interview.flac out.txt \
 
 MIT © Leandro Piccione
 
+
+## Web Interface
+
+A simple Flask web server is provided to run the transcription through a browser.
+
+### Usage
+
+```bash
+pip install -r requirements.txt
+python webapp.py
+```
+
+Open `http://localhost:5000` and upload an audio file. Select desired options,
+start the transcription and follow the progress. Once finished, the transcript
+can be viewed in the browser or downloaded as a text file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pydub==0.25.1
 torch>=2.7.1
 tqdm==4.67.1
 soundfile==0.12.1
+Flask==2.3.2

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Whisper Transcription</title>
+  <style>
+  body { padding-top: 40px; }
+  </style>
+</head>
+<body>
+<div class="container">
+  {% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,41 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="mb-4 text-center">Audio to Text</h2>
+<form method="post" action="/start" enctype="multipart/form-data" class="row g-3">
+  <div class="col-12">
+    <input class="form-control" type="file" name="audio" required>
+  </div>
+  <div class="col-md-6">
+    <label class="form-label">Language code</label>
+    <input class="form-control" type="text" name="language" placeholder="auto">
+  </div>
+  <div class="col-md-6">
+    <label class="form-label">Mode</label>
+    <select class="form-select" name="mode">
+      <option value="api" selected>OpenAI API</option>
+      <option value="local">Local</option>
+    </select>
+  </div>
+  <div class="col-md-6">
+    <label class="form-label">Local model tag</label>
+    <input class="form-control" type="text" name="local_model" value="base">
+  </div>
+  <div class="col-12">
+    <div class="form-check form-check-inline">
+      <input class="form-check-input" type="checkbox" name="diarize" id="diarize">
+      <label class="form-check-label" for="diarize">Speaker detection</label>
+    </div>
+    <div class="form-check form-check-inline">
+      <input class="form-check-input" type="checkbox" name="aggregate" id="aggregate">
+      <label class="form-check-label" for="aggregate">Aggregate lines</label>
+    </div>
+    <div class="form-check form-check-inline">
+      <input class="form-check-input" type="checkbox" name="timestamps" id="timestamps">
+      <label class="form-check-label" for="timestamps">Include timestamps</label>
+    </div>
+  </div>
+  <div class="col-12 text-center">
+    <button type="submit" class="btn btn-primary">Start</button>
+  </div>
+</form>
+{% endblock %}

--- a/templates/status.html
+++ b/templates/status.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="mb-3 text-center">Processing…</h2>
+<pre id="log" class="bg-light p-3" style="height:300px;overflow:auto"></pre>
+<div id="done" style="display:none">
+  <h3 class="mt-4">Transcript</h3>
+  <pre id="result" class="bg-light p-3" style="white-space:pre-wrap"></pre>
+  <a id="download" class="btn btn-success mt-2" href="#" download>Download</a>
+</div>
+<script>
+const jobId = "{{ job_id }}";
+async function poll() {
+  const r = await fetch(`/logs/${jobId}`);
+  if (!r.ok) return;
+  const data = await r.json();
+  document.getElementById('log').textContent = data.log;
+  if (data.status === 'done') {
+    document.getElementById('result').textContent = data.result;
+    document.getElementById('download').href = `/download/${jobId}`;
+    document.getElementById('done').style.display = 'block';
+  } else if (data.status === 'error') {
+    document.getElementById('done').innerHTML = '<p class="text-danger">An error occurred.</p>';
+    document.getElementById('done').style.display = 'block';
+  } else {
+    setTimeout(poll, 1000);
+  }
+}
+poll();
+</script>
+{% endblock %}

--- a/webapp.py
+++ b/webapp.py
@@ -92,4 +92,4 @@ def download(job_id):
     return send_file(job.outfile, as_attachment=True, download_name='transcript.txt')
 
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0')
+    app.run(debug=True, host='0.0.0.0', port=8888)

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,95 @@
+import os
+import sys
+import uuid
+import threading
+import subprocess
+from flask import Flask, render_template, request, redirect, url_for, jsonify, send_file
+
+app = Flask(__name__)
+
+JOBS = {}
+UPLOAD_DIR = os.path.join(os.path.dirname(__file__), 'uploads')
+RESULT_DIR = os.path.join(os.path.dirname(__file__), 'results')
+os.makedirs(UPLOAD_DIR, exist_ok=True)
+os.makedirs(RESULT_DIR, exist_ok=True)
+
+class Job:
+    def __init__(self, infile, opts):
+        self.id = str(uuid.uuid4())
+        self.infile = infile
+        self.opts = opts
+        self.outfile = os.path.join(RESULT_DIR, f"{self.id}.txt")
+        self.log = []
+        self.status = 'running'
+
+    def run(self):
+        cmd = [sys.executable, 'script.py', self.infile, self.outfile]
+        if self.opts.get('mode'):
+            cmd += ['--mode', self.opts['mode']]
+        if self.opts.get('local_model'):
+            cmd += ['--local-model', self.opts['local_model']]
+        if self.opts.get('diarize'):
+            cmd.append('--diarize')
+        if self.opts.get('language'):
+            cmd += ['--language', self.opts['language']]
+        if self.opts.get('timestamps'):
+            cmd.append('--timestamps')
+        if self.opts.get('aggregate'):
+            cmd.append('--aggregate')
+
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        for line in proc.stdout:
+            self.log.append(line)
+        proc.wait()
+        if proc.returncode == 0:
+            self.status = 'done'
+        else:
+            self.status = 'error'
+        self.log.append(f"[END] exit code {proc.returncode}\n")
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/start', methods=['POST'])
+def start():
+    f = request.files['audio']
+    filename = os.path.join(UPLOAD_DIR, f"{uuid.uuid4()}_{f.filename}")
+    f.save(filename)
+    opts = {
+        'language': request.form.get('language') or None,
+        'diarize': bool(request.form.get('diarize')),
+        'mode': request.form.get('mode'),
+        'local_model': request.form.get('local_model'),
+        'aggregate': bool(request.form.get('aggregate')),
+        'timestamps': bool(request.form.get('timestamps')),
+    }
+    job = Job(filename, opts)
+    JOBS[job.id] = job
+    threading.Thread(target=job.run, daemon=True).start()
+    return redirect(url_for('status', job_id=job.id))
+
+@app.route('/status/<job_id>')
+def status(job_id):
+    return render_template('status.html', job_id=job_id)
+
+@app.route('/logs/<job_id>')
+def logs(job_id):
+    job = JOBS.get(job_id)
+    if not job:
+        return jsonify({'error': 'job not found'}), 404
+    data = {'status': job.status, 'log': ''.join(job.log)}
+    if job.status == 'done':
+        with open(job.outfile, 'r', encoding='utf-8') as fh:
+            data['result'] = fh.read()
+    return jsonify(data)
+
+@app.route('/download/<job_id>')
+def download(job_id):
+    job = JOBS.get(job_id)
+    if not job or job.status != 'done':
+        return 'Not ready', 404
+    return send_file(job.outfile, as_attachment=True, download_name='transcript.txt')
+
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0')


### PR DESCRIPTION
## Summary
- implement Flask web server for running the transcription
- add Bootstrap HTML templates for audio upload, status updates and result download
- document how to use the new web interface
- include Flask dependency

## Testing
- `python -m py_compile script.py webapp.py`


------
https://chatgpt.com/codex/tasks/task_e_685c1db28d588329bc6cef64437ef300